### PR TITLE
Feature/user delete

### DIFF
--- a/crud/user.py
+++ b/crud/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import or_
+from sqlalchemy import or_, update
 from sqlalchemy.orm import Session
 
 from schemas.user import createUser
@@ -44,3 +44,12 @@ def get_duplicate_user(
         return True
     return False
 
+def delete_user(
+    user_id: int, 
+    db: Session
+)-> User:
+    db.execute(update(User).where(User.id == user_id).values(is_deleted=True))
+
+    db.commit()
+
+    return

--- a/crud/user.py
+++ b/crud/user.py
@@ -11,6 +11,7 @@ def create_user(
 ) -> User:
 
     db_obj = User(
+        id              =signup_info.id,
         username        = signup_info.username,
         password        = signup_info.password,
         name            = signup_info.name,
@@ -19,6 +20,7 @@ def create_user(
         phone           = signup_info.phone,
         email           = signup_info.email,
         user_type       = signup_info.user_type,
+        joined_at       = signup_info.joined_at,
         is_deleted      = signup_info.is_deleted
     )
 
@@ -28,11 +30,10 @@ def create_user(
 
     return db_obj
 
-
 def get_duplicate_user(
     signup_info: createUser,
     db: Session
-):
+)-> bool:
     user = db.query(User).filter(
                             or_(
                             User.username == signup_info.username,
@@ -47,7 +48,7 @@ def get_duplicate_user(
 def delete_user(
     user_id: int, 
     db: Session
-)-> User:
+)-> None:
     db.execute(update(User).where(User.id == user_id).values(is_deleted=True))
 
     db.commit()

--- a/crud/user.py
+++ b/crud/user.py
@@ -53,3 +53,4 @@ def delete_user(
     db.commit()
 
     return
+

--- a/database/models.py
+++ b/database/models.py
@@ -2,7 +2,9 @@ from enum import Enum as enum_type
 
 from sqlalchemy     import Table, MetaData, Column, Integer, Enum, String, Boolean, DateTime
 from sqlalchemy.sql import func, expression
-from sqlalchemy.orm import mapper
+from sqlalchemy.orm import registry
+
+mapper_registry = registry()
 
 metadata = MetaData()
 
@@ -40,5 +42,5 @@ class User(object):
         self.is_deleted      = is_deleted
 
 
-mapper(User, user)
+mapper_registry.map_imperatively(User, user)
 

--- a/database/models.py
+++ b/database/models.py
@@ -30,7 +30,8 @@ user = Table('user', metadata,
 
 
 class User(object):
-    def __init__(self, username, password, name, registration_no, address, phone, email, user_type, is_deleted):
+    def __init__(self, id, username, password, name, registration_no, address, phone, email, user_type, joined_at, is_deleted):
+        self.id              = id
         self.username        = username
         self.password        = password
         self.name            = name
@@ -39,6 +40,7 @@ class User(object):
         self.phone           = phone
         self.email           = email
         self.user_type       = user_type
+        self.joined_at       = joined_at
         self.is_deleted      = is_deleted
 
 

--- a/routers/user.py
+++ b/routers/user.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 
 from database.session import get_db
 
-from schemas.user import createUser
+from schemas.user import createUser, deleteUser
 
 from utils.auth import get_password_hash
 
 from crud.user import (
     create_user,
-    get_duplicate_user
+    get_duplicate_user,
+    delete_user
 )
 
 router = APIRouter()
@@ -33,4 +34,12 @@ def signup(
     
     return {'message': 'SIGNUP SUCCESS!'}
 
+@router.delete("/delete", status_code=204, response_class=Response)
+def logout(
+    user_info: deleteUser,
+    db = db
+):
+    delete_user(user_info.user_id, db)
+
+    return
 

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -2,9 +2,12 @@ import re
 
 from pydantic import BaseModel, validator
 
+from typing import Union
+
 from database.models import UserType
 
 class createUser(BaseModel):
+    id: Union[int, None]
     username: str
     password: str
     name: str
@@ -13,6 +16,7 @@ class createUser(BaseModel):
     phone: str
     email: str
     user_type: UserType
+    joined_at: Union[str, None]
     is_deleted: bool
 
     @validator('username')

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -33,4 +33,5 @@ class createUser(BaseModel):
             raise ValueError('유효하지 않은 이메일 양식입니다.')
         return v
 
-
+class deleteUser(BaseModel):
+    user_id: int

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -35,3 +35,4 @@ class createUser(BaseModel):
 
 class deleteUser(BaseModel):
     user_id: int
+


### PR DESCRIPTION
### PR 목적
- 회원 삭제 기능

### 작업 내용
- User 삭제 (soft delete, `is_deleted` = True로 변경)
- DB mapping function 변경 (sqlalchemy 버전에 따라 `mapper()` ->`registry.map_imperatively()` 사용)
   -> Error message: "The 'sqlalchemy.orm.mapper()' function is removed as of SQLAlchemy 2.0.  
        Use the 'sqlalchemy.orm.registry.map_imperatively()` method of the ``sqlalchemy.orm.registry`` class 
        to perform classical mapping."
- id=2 계정 삭제한 예시 캡처
<img width="942" alt="스크린샷 2023-04-15 오전 12 42 25" src="https://user-images.githubusercontent.com/97735091/232091355-00a75c27-ce68-4729-94f4-d140f2c49ddb.png">

### 기타 코멘트

