### PR TITLE
add searching feature by location

### DIFF
--- a/crud/cafe.py
+++ b/crud/cafe.py
@@ -1,5 +1,9 @@
+from sqlalchemy import between, and_
 from sqlalchemy.orm import Session
+
 from database.models import Cafe
+
+from utils.location import calculate_bound
 
 def get_total_cafe_name_list(db = Session) -> Cafe:
     cafe_list = db.query(Cafe).with_entities(Cafe.name).all()
@@ -28,4 +32,20 @@ def update_new_cafe(
     db.refresh(cafe)
 
     return
+
+def get_cafe_list_by_location(
+    lat: float,
+    lng: float,
+    db: Session
+):
+    bounds = calculate_bound(lat, lng)
+
+    cafe_list = db.query(Cafe).where(
+                    and_(
+                        between(Cafe.lat, bounds['min_lat'], bounds['max_lat']),
+                        between(Cafe.lng, bounds['min_lng'], bounds['max_lng'])
+                    )
+                ).all()
+
+    return cafe_list
 

--- a/routers/cafe.py
+++ b/routers/cafe.py
@@ -1,0 +1,27 @@
+import requests
+from fastapi import APIRouter, Depends
+
+from database.session import get_db
+
+from utils.config import settings
+
+from crud.cafe import get_cafe_list_by_location
+
+router = APIRouter()
+
+db = Depends(get_db)
+
+GOOGLE_KEY = settings.google_api_key
+
+@router.get("/location", status_code=200)
+def search_total_cafe_by_location(db = db) -> dict:
+    ip_url = f"https://www.googleapis.com/geolocation/v1/geolocate?key={GOOGLE_KEY}"
+    config = {'considerIp': True}
+
+    data = requests.post(ip_url, config)
+    current_location = data.json()
+
+    cafe_list = get_cafe_list_by_location(current_location['location']['lat'], current_location['location']['lng'], db)
+
+    return cafe_list
+

--- a/routers/router.py
+++ b/routers/router.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
 from .user import router as user_router
+from .cafe import router as cafe_router
 
 api_router = APIRouter()
 
 api_router.include_router(user_router, prefix="/user")
+api_router.include_router(cafe_router, prefix="/cafe")
 

--- a/scheduler/cafe_info.py
+++ b/scheduler/cafe_info.py
@@ -10,7 +10,6 @@ from utils.config import settings
 from crud.cafe import get_total_cafe_name_list, update_new_cafe
 from database.session import get_db
 
-GOOGLE_KEY = settings.google_api_key
 KAKAO_KEY  = settings.kakao_api_key
 
 def get_facility_info(facility_url: str) -> dict:

--- a/utils/location.py
+++ b/utils/location.py
@@ -1,0 +1,18 @@
+import math
+
+def calculate_bound(
+    lat:float, 
+    lng:float
+)-> dict:
+    lat_change = 1 / 111.2
+    lng_change = abs(math.cos(lat * (math.pi / 180)))
+
+    bounds = {
+        'min_lat': lat - lat_change,
+        'min_lng': lng - lng_change,
+        'max_lat': lat + lat_change,
+        'max_lng': lng - lng_change
+    }
+
+    return bounds
+


### PR DESCRIPTION
### PR 목적
- 현재 위치 기반 카페 검색(조회) 기능

### 작업 내용
- 사용자가 따로 검색어를 입력하지 않으면(e.g. wifi, 반려견 등), 현재 위치 기준으로 반경 1km 내에 있는 카페 조회
- `GOOGLE_KEY` 는 카페 조회 시 필요하므로 기존의 카페 DB업데이트에 작성되어 있던 google key는 제거 

### 기타 코멘트
- 위/경도 기준으로 반경 계산하는 공식이 맞는지 확인이 어려운데 혹시 참고할 사이트 있다면 알 수 있을까요? 
   (제가 참고한 블로그는 [여기](https://jangwon.io/django/2018/10/15/(Django)-%EC%9C%84%EB%8F%84-%EA%B2%BD%EB%8F%84%EB%A1%9C-%ED%95%84%ED%84%B0%EB%A7%81%ED%95%98%EA%B8%B0/)입니다)
- 검색어가 추가로 있는 경우는 이후 추가할 예정입니다
